### PR TITLE
Update configure-deprovisioned-apps.yml

### DIFF
--- a/src/Configuration/sw/registry/configure-deprovisioned-apps.yml
+++ b/src/Configuration/sw/registry/configure-deprovisioned-apps.yml
@@ -98,3 +98,7 @@ actions:
   - !registryKey: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned\Microsoft.Office.Excel_8wekyb3d8bbwe', operation: add}
   - !registryKey: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned\Microsoft.Office.PowerPoint_8wekyb3d8bbwe', operation: add}
   - !registryKey: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Appx\AppxAllUserStore\Deprovisioned\Microsoft.Office.Word_8wekyb3d8bbwe', operation: add}
+    # -------> Dev Home
+  - !registryKey: {path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\DevHomeUpdate', operation: delete}
+    # -------> Outlook (New)
+  - !registryKey: {path: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\OutlookUpdate', operation: delete}


### PR DESCRIPTION
Add some registry entries to prevent ‘Dev Home’ and ‘Outlook (New)’ from being installed automatically by deleting those keys.